### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: ci
+permissions:
+  contents: read
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/infinite-kube/RapidPatch-DepBot/security/code-scanning/1](https://github.com/infinite-kube/RapidPatch-DepBot/security/code-scanning/1)

To fix this issue, we should explicitly set a `permissions` block in the workflow `.github/workflows/ci.yml`. Since the workflow only needs to read the repository contents (to check out code and run audits), we can add the following minimal permissions block at the top level of the workflow (so it applies to all jobs), directly after the `name:` field and before the `on:` field.  
No changes to any other files or code blocks are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
